### PR TITLE
Add Gregslist job board and hiring manager

### DIFF
--- a/src/gregslist/component.rs
+++ b/src/gregslist/component.rs
@@ -1,0 +1,23 @@
+use bevy::prelude::*;
+use std::collections::HashSet;
+
+#[derive(Resource, Default)]
+pub struct Gregslist {
+    pub ads: Vec<Advert>,
+    pub index: HashSet<(Entity, usize)>,
+}
+
+pub struct Advert {
+    pub job: Entity,
+    pub role_index: usize,
+    pub date_posted: f32,
+}
+
+#[derive(Resource)]
+pub struct GregslistConfig {
+    pub expiry_secs: f32,
+}
+#[derive(Event)]
+pub struct VacancyDirty {
+    pub job: Entity,
+}

--- a/src/gregslist/mod.rs
+++ b/src/gregslist/mod.rs
@@ -1,0 +1,7 @@
+pub mod component;
+
+pub mod plugin;
+
+pub use plugin::GregslistPlugin;
+
+pub use component::{Advert, Gregslist, GregslistConfig, VacancyDirty};

--- a/src/gregslist/plugin.rs
+++ b/src/gregslist/plugin.rs
@@ -1,0 +1,77 @@
+use bevy::prelude::*;
+
+use super::component::{Advert, Gregslist, GregslistConfig, VacancyDirty};
+
+pub struct GregslistPlugin {
+    expiry_secs: f32,
+}
+
+impl GregslistPlugin {
+    pub fn new(expiry_secs: f32) -> Self {
+        Self { expiry_secs }
+    }
+}
+
+impl Plugin for GregslistPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<Gregslist>();
+        app.insert_resource(GregslistConfig {
+            expiry_secs: self.expiry_secs,
+        });
+        app.add_event::<VacancyDirty>();
+        app.add_systems(Update, (gregslist_cleaner, hiring_manager_post).chain());
+    }
+}
+
+fn gregslist_cleaner(
+    time: Res<Time>,
+    config: Res<GregslistConfig>,
+    mut board: ResMut<Gregslist>,
+    mut dirty: EventWriter<VacancyDirty>,
+) {
+    let now = time.elapsed_secs();
+    let mut expired: Vec<(Entity, usize)> = Vec::new();
+    board.ads.retain(|ad| {
+        if now - ad.date_posted > config.expiry_secs {
+            expired.push((ad.job, ad.role_index));
+            false
+        } else {
+            true
+        }
+    });
+    for (job, role_index) in expired {
+        board.index.remove(&(job, role_index));
+        dirty.send(VacancyDirty { job });
+    }
+}
+
+fn hiring_manager_post(
+    mut events: EventReader<VacancyDirty>,
+    jobs: Query<&crate::jobs::component::Job>,
+    mut board: ResMut<Gregslist>,
+    time: Res<Time>,
+) {
+    let now = time.elapsed_secs();
+    for ev in events.read() {
+        if let Ok(job) = jobs.get(ev.job) {
+            for (i, (spec, members)) in job.roles.iter().enumerate() {
+                let vacancy = spec.min.saturating_sub(members.len() as u32);
+                let key = (ev.job, i);
+                if vacancy > 0 {
+                    if !board.index.contains(&key) {
+                        board.ads.push(Advert {
+                            job: ev.job,
+                            role_index: i,
+                            date_posted: now,
+                        });
+                        board.index.insert(key);
+                    }
+                } else if board.index.remove(&key) {
+                    board
+                        .ads
+                        .retain(|ad| !(ad.job == ev.job && ad.role_index == i));
+                }
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 use bevy::prelude::*;
 
 mod baby_spawner;
+mod gregslist;
 mod inventory;
 mod jobs;
 mod mortality;
@@ -58,6 +59,7 @@ fn main() {
         .add_plugins(records::RecordsPlugin)
         .add_plugins(mortality::MortalityPlugin)
         .add_plugins(jobs::JobsPlugin)
+        .add_plugins(gregslist::GregslistPlugin::new(60.0))
         .add_systems(Startup, spawn_jobs)
         //.add_systems(Startup, |mut time: ResMut<Time<Virtual>>| {
         //    time.set_relative_speed(DAY as f32);


### PR DESCRIPTION
Add Gregslist job board with HiringManager + Cleaner systems

- Introduced `Gregslist` resource that holds active job adverts.
- Each advert records: job entity, role index, and date posted.
- Added `VacancyDirty` event so jobs can notify the hiring manager
  when their vacancies change.
- HiringManager system:
  - listens for `VacancyDirty` events,
  - ensures there is exactly one advert for each vacant role,
  - removes adverts immediately if the role is filled.
- Cleaner system:
  - periodically prunes adverts older than the configured expiry window,
  - emits `VacancyDirty` so the manager can re-post if still vacant.
- All wiring contained in `GregslistPlugin`, configured with `expiry_secs`
  when added in `main`.

This sets up the foundation for posting and expiring job adverts without
scanning all jobs every frame.