### PR TITLE
Clarify gregslist expiration system and split hiring manager plugin

### DIFF
--- a/src/gregslist/mod.rs
+++ b/src/gregslist/mod.rs
@@ -2,6 +2,6 @@ pub mod component;
 
 pub mod plugin;
 
-pub use plugin::GregslistPlugin;
+pub use plugin::{GregslistPlugin, gregslist_expiration_system};
 
 pub use component::{Advert, Gregslist, GregslistConfig, VacancyDirty};

--- a/src/hiring_manager/mod.rs
+++ b/src/hiring_manager/mod.rs
@@ -1,0 +1,3 @@
+pub mod plugin;
+
+pub use plugin::HiringManagerPlugin;

--- a/src/hiring_manager/plugin.rs
+++ b/src/hiring_manager/plugin.rs
@@ -1,0 +1,44 @@
+use bevy::prelude::*;
+
+use crate::gregslist::{Advert, Gregslist, VacancyDirty};
+use crate::gregslist::plugin::gregslist_expiration_system;
+use crate::jobs::Job;
+
+pub struct HiringManagerPlugin;
+
+impl Plugin for HiringManagerPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, post_on_gregslist.after(gregslist_expiration_system));
+    }
+}
+
+pub fn post_on_gregslist(
+    mut events: EventReader<VacancyDirty>,
+    jobs: Query<&Job>,
+    mut board: ResMut<Gregslist>,
+    time: Res<Time>,
+) {
+    let now = time.elapsed_secs();
+    for ev in events.read() {
+        if let Ok(job) = jobs.get(ev.job) {
+            for (i, (spec, members)) in job.roles.iter().enumerate() {
+                let vacancy = spec.min.saturating_sub(members.len() as u32);
+                let key = (ev.job, i);
+                if vacancy > 0 {
+                    if !board.index.contains(&key) {
+                        board.ads.push(Advert {
+                            job: ev.job,
+                            role_index: i,
+                            date_posted: now,
+                        });
+                        board.index.insert(key);
+                    }
+                } else if board.index.remove(&key) {
+                    board
+                        .ads
+                        .retain(|ad| !(ad.job == ev.job && ad.role_index == i));
+                }
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use bevy::prelude::*;
 
 mod baby_spawner;
 mod gregslist;
+mod hiring_manager;
 mod inventory;
 mod jobs;
 mod mortality;
@@ -60,6 +61,7 @@ fn main() {
         .add_plugins(mortality::MortalityPlugin)
         .add_plugins(jobs::JobsPlugin)
         .add_plugins(gregslist::GregslistPlugin::new(60.0))
+        .add_plugins(hiring_manager::HiringManagerPlugin)
         .add_systems(Startup, spawn_jobs)
         //.add_systems(Startup, |mut time: ResMut<Time<Virtual>>| {
         //    time.set_relative_speed(DAY as f32);


### PR DESCRIPTION
## Summary
- rename poorly named `gregslist_cleaner` to clearer `gregslist_expiration_system`
- move job posting logic into new `HiringManagerPlugin` with `post_on_gregslist` system
- register the new plugin in the main app

## Testing
- `cargo check --features graphics` *(fails: `The system library alsa required by crate alsa-sys was not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68b7846f1870832a8b8deae45fa8cef0