### PR TITLE
use generic Time<Virtual> resource

### DIFF
--- a/src/baby_spawner/system.rs
+++ b/src/baby_spawner/system.rs
@@ -19,7 +19,7 @@ impl FromWorld for GameRNG {
 
 pub fn spawn_babies(
     mut commands: Commands,
-    time: Res<Time>,
+    time: Res<Time<Virtual>>,
     cfg: Res<BabySpawnerConfig>,
     mut rng: ResMut<GameRNG>,
     mut writer: EventWriter<BabyBorn>,

--- a/src/gregslist/plugin.rs
+++ b/src/gregslist/plugin.rs
@@ -26,7 +26,7 @@ impl Plugin for GregslistPlugin {
 }
 
 fn gregslist_expiration_system(
-    time: Res<Time>,
+    time: Res<Time<Virtual>>,
     cfg: Res<GregslistConfig>,
     mut board: ResMut<Gregslist>,
     mut dirty: EventWriter<VacancyDirty>,

--- a/src/hiring_manager/plugin.rs
+++ b/src/hiring_manager/plugin.rs
@@ -37,7 +37,7 @@ fn mark_jobs_dirty_on_startup(
 
 // Post/remove adverts so Gregslist reflects current vacancies for dirty jobs.
 fn post_job_openings(
-    time: Res<Time>,
+    time: Res<Time<Virtual>>,
     mut board: ResMut<Gregslist>,
     mut dirty_events: EventReader<VacancyDirty>,
     jobs: Query<&Job>,

--- a/src/mortality/system.rs
+++ b/src/mortality/system.rs
@@ -10,11 +10,11 @@ use crate::person::Person;
 /// Every time step, with a given probability, kill an entity.
 pub fn apply_mortality_with_rate(
     rate_per_sec_per_person: f64,
-) -> impl FnMut(Res<Time>, ResMut<GameRNG>, Query<Entity, With<Person>>, EventWriter<Death>)
+) -> impl FnMut(Res<Time<Virtual>>, ResMut<GameRNG>, Query<Entity, With<Person>>, EventWriter<Death>)
        + Send
        + Sync
        + 'static {
-    move |time: Res<Time>,
+    move |time: Res<Time<Virtual>>,
           mut rng: ResMut<GameRNG>,
           people: Query<Entity, With<Person>>,
           mut writer: EventWriter<Death>| {


### PR DESCRIPTION
## Summary
- use `Res<Time<Virtual>>` everywhere to match Bevy 0.16 time resource

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68b8f1b3d2b8832a8b40f791bf431177