### PR TITLE
Explicitly import Time and Virtual

### DIFF
--- a/src/baby_spawner/system.rs
+++ b/src/baby_spawner/system.rs
@@ -1,6 +1,6 @@
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
-use bevy_time::prelude::*;
+use bevy_time::{Time, Virtual};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use rand_distr::{Distribution, Poisson};

--- a/src/gregslist/plugin.rs
+++ b/src/gregslist/plugin.rs
@@ -1,6 +1,6 @@
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
-use bevy_time::prelude::*;
+use bevy_time::{Time, Virtual};
 
 use super::component::{Gregslist, GregslistConfig, VacancyDirty};
 

--- a/src/hiring_manager/plugin.rs
+++ b/src/hiring_manager/plugin.rs
@@ -1,6 +1,6 @@
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
-use bevy_time::prelude::*;
+use bevy_time::{Time, Virtual};
 
 use crate::gregslist::component::{Gregslist, VacancyDirty, Advert};
 use crate::jobs::component::{Job, Constraint};

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@
 
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
-use bevy_time::prelude::*;
+use bevy_time::{Time, Virtual};
 
 mod baby_spawner;
 mod gregslist;

--- a/src/mortality/system.rs
+++ b/src/mortality/system.rs
@@ -1,6 +1,6 @@
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
-use bevy_time::prelude::*;
+use bevy_time::{Time, Virtual};
 use rand::Rng;
 
 use crate::baby_spawner::system::GameRNG; // your RNG resource

--- a/src/records/records.rs
+++ b/src/records/records.rs
@@ -3,7 +3,7 @@ use crate::mortality::Death;
 use crate::records::RollingMean;
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
-use bevy_time::prelude::*;
+use bevy_time::{Time, Virtual};
 
 #[derive(Resource, Debug, Clone)]
 pub struct Records {

--- a/src/records/ui.rs
+++ b/src/records/ui.rs
@@ -1,5 +1,6 @@
 use crate::records::Records;
 use bevy::prelude::*;
+use bevy::time::{Time, Virtual};
 
 #[derive(Resource)]
 pub struct PopulationText(pub Entity);


### PR DESCRIPTION
## Summary
- Explicitly import `Time` and `Virtual` in all systems to clarify use of `Time<Virtual>` resource
- Ensure time-based systems like gregslist expiration, job postings, baby spawning, mortality, and records operate on `Time<Virtual>`

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68b97c35eec8832ab87c79048b72e870