### PR TITLE
fix bevy graphics import

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_time::{Time, Real};
+#[cfg(feature = "graphics")]
+use bevy::prelude::DefaultPlugins;
 
 mod baby_spawner;
 mod gregslist;


### PR DESCRIPTION
## Summary
- import `bevy::prelude::DefaultPlugins` when graphics feature enabled to get windowing plugins

## Testing
- `cargo build --features graphics && echo BuildOK`


------
https://chatgpt.com/codex/tasks/task_e_68b981ef7344832aa5faa4a7b102bf9d