### PR TITLE
fix bevy graphics import

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,15 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 
+#[cfg(feature = "graphics")]
+use bevy::prelude::DefaultPlugins;
+#[cfg(not(feature = "graphics"))]
+use bevy_app::ScheduleRunnerPlugin;
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
-use bevy_time::{Time, Real};
+#[cfg(not(feature = "graphics"))]
+use bevy_log::LogPlugin;
+use bevy_time::{Real, Time};
 
 mod baby_spawner;
 mod gregslist;
@@ -64,7 +70,11 @@ fn main() {
     }
     #[cfg(not(feature = "graphics"))]
     {
-        app.add_plugins(bevy_time::TimePlugin::default());
+        app.add_plugins((
+            bevy_time::TimePlugin::default(),
+            LogPlugin::default(),
+            ScheduleRunnerPlugin::default(),
+        ));
     }
     app.add_plugins(BabySpawnerPlugin)
         .add_plugins(records::RecordsPlugin)


### PR DESCRIPTION
## Summary
- import `bevy::prelude::DefaultPlugins` when graphics feature enabled to get windowing plugins
- add `ScheduleRunnerPlugin` and logging for headless runs so the app keeps ticking without graphics

## Testing
- `cargo run` (prints "1 weeks have passed" after a few seconds)
- `cargo run --features graphics` *(fails: neither WAYLAND_DISPLAY nor WAYLAND_SOCKET nor DISPLAY is set)*

------
https://chatgpt.com/codex/tasks/task_e_68b981ef7344832aa5faa4a7b102bf9d