### PR TITLE
Implement job application logic and employment UI

### DIFF
--- a/src/records/plugin.rs
+++ b/src/records/plugin.rs
@@ -1,7 +1,9 @@
 use crate::records::Records;
-use crate::records::{record_births, record_deaths};
 #[cfg(feature = "graphics")]
-use crate::records::ui::{spawn_population_text, update_population_text};
+use crate::records::ui::{
+    spawn_employment_text, spawn_population_text, update_employment_text, update_population_text,
+};
+use crate::records::{record_births, record_deaths};
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_time::prelude::*;
@@ -11,8 +13,9 @@ pub struct RecordsPlugin;
 impl Plugin for RecordsPlugin {
     fn build(&self, app: &mut App) {
         #[cfg(feature = "graphics")]
-        app.add_systems(Startup, spawn_population_text)
-            .add_systems(Update, update_population_text);
+        app.add_systems(Startup, (spawn_population_text, spawn_employment_text))
+            .add_systems(Update, (update_population_text, update_employment_text));
+
         app.add_systems(Update, (record_births, record_deaths));
     }
 }


### PR DESCRIPTION
## Summary
- Apply unemployed agents to matching job adverts via `apply_for_jobs`
- Display "Employed: N" UI showing number of employed residents

## Testing
- `cargo test`
- `cargo test --features graphics`


------
https://chatgpt.com/codex/tasks/task_e_68bf1a189384832ab6b90751c5173088