### PR TITLE
Add employment rate tracking

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,11 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 
-use bevy_app::prelude::*;
-use bevy_ecs::prelude::*;
-use bevy_time::{Time, Real};
 #[cfg(feature = "graphics")]
 use bevy::prelude::DefaultPlugins;
+use bevy_app::prelude::*;
+use bevy_ecs::prelude::*;
+use bevy_time::{Real, Time};
 
 mod baby_spawner;
 mod gregslist;
@@ -22,7 +22,7 @@ mod view;
 use crate::baby_spawner::{BabySpawnerConfig, BabySpawnerPlugin};
 use crate::inventory::InventoryPlugin;
 use crate::mortality::system::apply_mortality_with_rate;
-use crate::records::{Records, rolling_mean::RollingMean};
+use crate::records::{rolling_mean::RollingMean, Records};
 use jobs::Job;
 
 const SEC: f64 = 1.0;
@@ -86,6 +86,7 @@ fn main() {
             deaths: 0,
             birth_rate: RollingMean::new(DAY),
             death_rate: RollingMean::new(DAY),
+            employment_rate: 0.0,
         })
         .add_systems(Update, {
             let deaths_per_sec_per_person = SPEED / (AVERAGE_LIFESPAN_YEARS * YR);

--- a/src/records/mod.rs
+++ b/src/records/mod.rs
@@ -4,8 +4,10 @@ pub mod rolling_mean;
 #[cfg(feature = "graphics")]
 pub mod ui;
 
-pub use self::records::{record_births, record_deaths, Records};
+pub use self::records::{record_births, record_deaths, record_employment_rate, Records};
 pub use self::rolling_mean::RollingMean;
 #[cfg(feature = "graphics")]
-pub use self::ui::{spawn_population_text, update_population_text};
+pub use self::ui::{
+    spawn_employment_text, spawn_population_text, update_employment_text, update_population_text,
+};
 pub use plugin::RecordsPlugin;

--- a/src/records/plugin.rs
+++ b/src/records/plugin.rs
@@ -1,9 +1,9 @@
-use crate::records::Records;
 #[cfg(feature = "graphics")]
 use crate::records::ui::{
     spawn_employment_text, spawn_population_text, update_employment_text, update_population_text,
 };
-use crate::records::{record_births, record_deaths};
+use crate::records::Records;
+use crate::records::{record_births, record_deaths, record_employment_rate};
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_time::prelude::*;
@@ -16,6 +16,9 @@ impl Plugin for RecordsPlugin {
         app.add_systems(Startup, (spawn_population_text, spawn_employment_text))
             .add_systems(Update, (update_population_text, update_employment_text));
 
-        app.add_systems(Update, (record_births, record_deaths));
+        app.add_systems(
+            Update,
+            (record_births, record_deaths, record_employment_rate),
+        );
     }
 }

--- a/src/records/records.rs
+++ b/src/records/records.rs
@@ -1,9 +1,11 @@
 use crate::baby_spawner::BabyBorn;
+use crate::hiring_manager::component::Unemployed;
 use crate::mortality::Death;
+use crate::person::Person;
 use crate::records::RollingMean;
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
-use bevy_time::{Time, Real};
+use bevy_time::{Real, Time};
 
 #[derive(Resource, Debug, Clone)]
 pub struct Records {
@@ -11,6 +13,7 @@ pub struct Records {
     pub deaths: usize,
     pub birth_rate: RollingMean,
     pub death_rate: RollingMean,
+    pub employment_rate: f32,
 }
 
 impl Records {
@@ -40,5 +43,20 @@ pub fn record_deaths(
     for _ in deaths.read() {
         records.deaths = records.deaths.saturating_add(1);
         records.death_rate.push(now);
+    }
+}
+
+pub fn record_employment_rate(
+    mut records: ResMut<Records>,
+    people: Query<Entity, With<Person>>,
+    unemployed: Query<Entity, With<Unemployed>>,
+) {
+    let total = people.iter().count();
+    let jobless = unemployed.iter().count();
+    if total > 0 {
+        let employed = total.saturating_sub(jobless);
+        records.employment_rate = employed as f32 / total as f32;
+    } else {
+        records.employment_rate = 0.0;
     }
 }

--- a/src/records/ui.rs
+++ b/src/records/ui.rs
@@ -2,9 +2,6 @@ use crate::records::Records;
 use bevy::prelude::*;
 use bevy::time::{Real, Time};
 
-use crate::hiring_manager::component::Unemployed;
-use crate::person::Person;
-
 #[derive(Resource)]
 pub struct PopulationText(pub Entity);
 
@@ -45,7 +42,7 @@ pub fn spawn_employment_text(mut commands: Commands, asset_server: Res<AssetServ
                 left: Val::Px(10.0),
                 ..default()
             },
-            Text::new("Employed: 0"),
+            Text::new("Employment: 0%"),
             TextFont {
                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                 font_size: 24.0,
@@ -84,15 +81,11 @@ pub fn update_population_text(
 }
 
 pub fn update_employment_text(
+    records: Res<Records>,
     mut q_text: Query<&mut Text>,
     text_entity: Res<EmploymentText>,
-    people: Query<Entity, With<Person>>,
-    unemployed: Query<Entity, With<Unemployed>>,
 ) {
     if let Ok(mut text) = q_text.get_mut(text_entity.0) {
-        let total = people.iter().count();
-        let jobless = unemployed.iter().count();
-        let employed = total.saturating_sub(jobless);
-        text.0 = format!("Employed: {}", employed);
+        text.0 = format!("Employment: {:.0}%", records.employment_rate * 100.0);
     }
 }


### PR DESCRIPTION
## Summary
- track employment percentage in `Records`
- update employment text UI to show percentage
- record employment rate each frame

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68bf24b3ba24832aa1c61c02259f3cad