### PR TITLE
Add game event helper and personality component

### DIFF
--- a/src/game_events.rs
+++ b/src/game_events.rs
@@ -1,0 +1,19 @@
+use bevy_ecs::prelude::*;
+
+pub fn game_event_system<E, T, R>(
+    mut trigger: T,
+    mut resolve: R,
+) -> impl FnMut(&mut World) + Send + Sync + 'static
+where
+    E: 'static,
+    T: FnMut(&World, &mut Vec<E>) + Send + Sync + 'static,
+    R: FnMut(&mut World, E) + Send + Sync + 'static,
+{
+    move |world: &mut World| {
+        let mut events = Vec::<E>::new();
+        trigger(world, &mut events);
+        for ev in events.drain(..) {
+            resolve(world, ev);
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,10 +12,12 @@ mod baby_spawner;
 mod gregslist;
 mod hiring_manager;
 mod graph;
+mod game_events;
 mod inventory;
 mod jobs;
 mod mortality;
 mod person;
+mod personality;
 mod records;
 #[cfg(feature = "graphics")]
 mod view;

--- a/src/personality.rs
+++ b/src/personality.rs
@@ -1,0 +1,24 @@
+use bevy_ecs::prelude::*;
+
+#[derive(Component, Clone, Copy, Debug)]
+pub struct Personality {
+    pub openness: f64,
+    pub conscientiousness: f64,
+    pub extraversion: f64,
+    pub agreeableness: f64,
+    pub neuroticism: f64,
+    pub intelligence: f64,
+}
+
+impl Personality {
+    pub fn as_array(&self) -> [f64; 6] {
+        [
+            self.openness,
+            self.conscientiousness,
+            self.extraversion,
+            self.agreeableness,
+            self.neuroticism,
+            self.intelligence,
+        ]
+    }
+}


### PR DESCRIPTION
## Summary
- add generic game event system to drive triggers and resolvers
- model personality traits component with OCEAN plus intelligence

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68c0a2b61d18832a96fcdd01a0e3d321