### PR TITLE
Add vacancy UI counter with tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,24 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+
+pub mod baby_spawner;
+pub mod gregslist;
+pub mod hiring_manager;
+pub mod graph;
+pub mod game_events;
+pub mod inventory;
+pub mod jobs;
+pub mod mortality;
+pub mod person;
+pub mod personality;
+pub mod records;
+#[cfg(feature = "graphics")]
+pub mod view;
+
+pub use baby_spawner::{BabySpawnerConfig, BabySpawnerPlugin};
+pub use gregslist::{Gregslist, Advert, GregslistPlugin, GregslistConfig, VacancyDirty};
+pub use hiring_manager::HiringManagerPlugin;
+pub use jobs::JobsPlugin;
+pub use mortality::MortalityPlugin;
+pub use records::{RecordsPlugin, VacancyText, VacancyTextPlugin};

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ mod view;
 use crate::baby_spawner::{BabySpawnerConfig, BabySpawnerPlugin};
 use crate::inventory::InventoryPlugin;
 use crate::mortality::system::apply_mortality_with_rate;
-use crate::records::{rolling_mean::RollingMean, Records};
+use crate::records::{rolling_mean::RollingMean, Records, VacancyTextPlugin};
 use jobs::Job;
 
 const SEC: f64 = 1.0;
@@ -76,8 +76,10 @@ fn main() {
         .add_plugins(mortality::MortalityPlugin)
         .add_plugins(jobs::JobsPlugin)
         .add_plugins(gregslist::GregslistPlugin::new(60.0))
-        .add_plugins(hiring_manager::HiringManagerPlugin::new(8))
-        .add_systems(Startup, spawn_jobs)
+        .add_plugins(hiring_manager::HiringManagerPlugin::new(8));
+    #[cfg(feature = "graphics")]
+    app.add_plugins(VacancyTextPlugin);
+    app.add_systems(Startup, spawn_jobs)
         //.add_systems(Startup, |mut time: ResMut<Time<Real>>| {
         //    time.set_relative_speed(DAY as f32);
         //})

--- a/src/records/mod.rs
+++ b/src/records/mod.rs
@@ -8,6 +8,13 @@ pub use self::records::{record_births, record_deaths, record_employment_rate, Re
 pub use self::rolling_mean::RollingMean;
 #[cfg(feature = "graphics")]
 pub use self::ui::{
-    spawn_employment_text, spawn_population_text, update_employment_text, update_population_text,
+    spawn_employment_text,
+    spawn_population_text,
+    spawn_vacancy_text,
+    update_employment_text,
+    update_population_text,
+    update_vacancy_text,
+    VacancyText,
+    VacancyTextPlugin,
 };
 pub use plugin::RecordsPlugin;

--- a/src/records/ui.rs
+++ b/src/records/ui.rs
@@ -1,4 +1,4 @@
-use crate::records::Records;
+use crate::{gregslist::Gregslist, records::Records};
 use bevy::prelude::*;
 use bevy::time::{Real, Time};
 
@@ -7,6 +7,9 @@ pub struct PopulationText(pub Entity);
 
 #[derive(Resource)]
 pub struct EmploymentText(pub Entity);
+
+#[derive(Component)]
+pub struct VacancyText;
 pub fn spawn_population_text(mut commands: Commands, asset_server: Res<AssetServer>) {
     let e = commands
         .spawn((
@@ -54,6 +57,25 @@ pub fn spawn_employment_text(mut commands: Commands, asset_server: Res<AssetServ
     commands.insert_resource(EmploymentText(e));
 }
 
+pub fn spawn_vacancy_text(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn((
+        VacancyText,
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(72.0),
+            left: Val::Px(10.0),
+            ..default()
+        },
+        Text::new("Open roles: 0"),
+        TextFont {
+            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+            font_size: 24.0,
+            ..default()
+        },
+        TextColor(Color::WHITE),
+    ));
+}
+
 pub fn update_population_text(
     time: Res<Time<Real>>,
     mut records: ResMut<Records>,
@@ -87,5 +109,23 @@ pub fn update_employment_text(
 ) {
     if let Ok(mut text) = q_text.get_mut(text_entity.0) {
         text.0 = format!("Employment: {:.0}%", records.employment_rate * 100.0);
+    }
+}
+
+pub fn update_vacancy_text(
+    greg: Res<Gregslist>,
+    mut q_text: Query<&mut Text, With<VacancyText>>,
+) {
+    if let Some(mut text) = q_text.iter_mut().next() {
+        text.0 = format!("Open roles: {}", greg.ads.len());
+    }
+}
+
+pub struct VacancyTextPlugin;
+
+impl Plugin for VacancyTextPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Startup, spawn_vacancy_text)
+            .add_systems(Update, update_vacancy_text);
     }
 }

--- a/tests/ui_vacancy_text.rs
+++ b/tests/ui_vacancy_text.rs
@@ -1,0 +1,72 @@
+#![cfg(feature = "graphics")]
+
+use bevy::prelude::*;
+use bevy::text::{Font, FontLoader};
+use simrs::{Gregslist, Advert, VacancyText, VacancyTextPlugin};
+
+fn dummy_ad() -> Advert {
+    Advert { job: Entity::from_raw(0), role_index: 0, date_posted: 0.0 }
+}
+
+fn app_with_vacancy_ui(board: Gregslist) -> App {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins)
+        .add_plugins(bevy::asset::AssetPlugin::default());
+    app.init_asset::<Font>();
+    app.init_asset_loader::<FontLoader>();
+    app.world_mut().insert_resource(board);
+    app.add_plugins(VacancyTextPlugin);
+    app
+}
+
+fn read_vacancy_text(app: &mut App) -> String {
+    let world = app.world_mut();
+    let mut q = world.query_filtered::<&Text, With<VacancyText>>();
+    let text = q.single(world).unwrap();
+    text.0.clone()
+}
+
+#[test]
+fn spawns_one_vacancy_text_on_startup() {
+    let board = Gregslist::default();
+    let mut app = app_with_vacancy_ui(board);
+    app.update();
+    let world = app.world_mut();
+    let mut q = world.query_filtered::<Entity, With<VacancyText>>();
+    let count = q.iter(world).count();
+    assert_eq!(count, 1);
+}
+
+#[test]
+fn vacancy_text_reflects_gregslist_len() {
+    let board = Gregslist::default();
+    let mut app = app_with_vacancy_ui(board);
+    app.update();
+    let s0 = read_vacancy_text(&mut app);
+    assert_eq!(s0, "Open roles: 0");
+    {
+        let mut g = app.world_mut().resource_mut::<Gregslist>();
+        g.ads.push(dummy_ad());
+        g.ads.push(dummy_ad());
+        g.ads.push(dummy_ad());
+    }
+    app.update();
+    let s1 = read_vacancy_text(&mut app);
+    assert_eq!(s1, "Open roles: 3");
+}
+
+#[test]
+fn vacancy_text_updates_after_hiring_drains_board() {
+    let mut board = Gregslist::default();
+    board.ads.push(dummy_ad());
+    board.ads.push(dummy_ad());
+    let mut app = app_with_vacancy_ui(board);
+    app.update();
+    {
+        let mut g = app.world_mut().resource_mut::<Gregslist>();
+        g.ads.clear();
+    }
+    app.update();
+    let s1 = read_vacancy_text(&mut app);
+    assert_eq!(s1, "Open roles: 0");
+}


### PR DESCRIPTION
## Summary
- display number of open roles via new VacancyText component and plugin
- re-export vacancy UI plugin and hook it into the main app
- test vacancy text spawning and updates using a lightweight Bevy app

## Testing
- `apt-get install -y libasound2-dev libudev-dev pkg-config`
- `cargo test --features graphics`

------
https://chatgpt.com/codex/tasks/task_e_68c706fe5098832a96dc4896d8305054