### PR TITLE
Gate graphics-only types behind feature flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,10 @@
 #![allow(unused_variables)]
 
 pub mod baby_spawner;
+pub mod game_events;
+pub mod graph;
 pub mod gregslist;
 pub mod hiring_manager;
-pub mod graph;
-pub mod game_events;
 pub mod inventory;
 pub mod jobs;
 pub mod mortality;
@@ -17,8 +17,10 @@ pub mod records;
 pub mod view;
 
 pub use baby_spawner::{BabySpawnerConfig, BabySpawnerPlugin};
-pub use gregslist::{Gregslist, Advert, GregslistPlugin, GregslistConfig, VacancyDirty};
+pub use gregslist::{Advert, Gregslist, GregslistConfig, GregslistPlugin, VacancyDirty};
 pub use hiring_manager::HiringManagerPlugin;
 pub use jobs::JobsPlugin;
 pub use mortality::MortalityPlugin;
-pub use records::{RecordsPlugin, VacancyText, VacancyTextPlugin};
+pub use records::RecordsPlugin;
+#[cfg(feature = "graphics")]
+pub use records::{VacancyText, VacancyTextPlugin};

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,10 @@ use bevy_ecs::prelude::*;
 use bevy_time::{Real, Time};
 
 mod baby_spawner;
+mod game_events;
+mod graph;
 mod gregslist;
 mod hiring_manager;
-mod graph;
-mod game_events;
 mod inventory;
 mod jobs;
 mod mortality;
@@ -25,7 +25,9 @@ mod view;
 use crate::baby_spawner::{BabySpawnerConfig, BabySpawnerPlugin};
 use crate::inventory::InventoryPlugin;
 use crate::mortality::system::apply_mortality_with_rate;
-use crate::records::{rolling_mean::RollingMean, Records, VacancyTextPlugin};
+#[cfg(feature = "graphics")]
+use crate::records::VacancyTextPlugin;
+use crate::records::{Records, rolling_mean::RollingMean};
 use jobs::Job;
 
 const SEC: f64 = 1.0;


### PR DESCRIPTION
## Summary
- gate VacancyText and VacancyTextPlugin re-exports behind `graphics` feature
- gate main import of VacancyTextPlugin

## Testing
- `cargo build`
- `cargo build --features graphics`
- `cargo test --features graphics`


------
https://chatgpt.com/codex/tasks/task_e_68c746851120832a938db4c192f78240