### PR TITLE
Gate graphics-only types behind feature flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,10 @@
 #![allow(unused_variables)]
 
 pub mod baby_spawner;
+pub mod game_events;
+pub mod graph;
 pub mod gregslist;
 pub mod hiring_manager;
-pub mod graph;
-pub mod game_events;
 pub mod inventory;
 pub mod jobs;
 pub mod mortality;
@@ -17,8 +17,10 @@ pub mod records;
 pub mod view;
 
 pub use baby_spawner::{BabySpawnerConfig, BabySpawnerPlugin};
-pub use gregslist::{Gregslist, Advert, GregslistPlugin, GregslistConfig, VacancyDirty};
+pub use gregslist::{Advert, Gregslist, GregslistConfig, GregslistPlugin, VacancyDirty};
 pub use hiring_manager::HiringManagerPlugin;
 pub use jobs::JobsPlugin;
 pub use mortality::MortalityPlugin;
-pub use records::{RecordsPlugin, VacancyText, VacancyTextPlugin};
+pub use records::RecordsPlugin;
+#[cfg(feature = "graphics")]
+pub use records::{VacancyText, VacancyTextPlugin};

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,10 @@ use bevy_ecs::prelude::*;
 use bevy_time::{Real, Time};
 
 mod baby_spawner;
+mod game_events;
+mod graph;
 mod gregslist;
 mod hiring_manager;
-mod graph;
-mod game_events;
 mod inventory;
 mod jobs;
 mod mortality;
@@ -25,7 +25,7 @@ mod view;
 use crate::baby_spawner::{BabySpawnerConfig, BabySpawnerPlugin};
 use crate::inventory::InventoryPlugin;
 use crate::mortality::system::apply_mortality_with_rate;
-use crate::records::{rolling_mean::RollingMean, Records, VacancyTextPlugin};
+use crate::records::{Records, rolling_mean::RollingMean};
 use jobs::Job;
 
 const SEC: f64 = 1.0;
@@ -77,8 +77,6 @@ fn main() {
         .add_plugins(jobs::JobsPlugin)
         .add_plugins(gregslist::GregslistPlugin::new(60.0))
         .add_plugins(hiring_manager::HiringManagerPlugin::new(8));
-    #[cfg(feature = "graphics")]
-    app.add_plugins(VacancyTextPlugin);
     app.add_systems(Startup, spawn_jobs)
         //.add_systems(Startup, |mut time: ResMut<Time<Real>>| {
         //    time.set_relative_speed(DAY as f32);

--- a/src/records/plugin.rs
+++ b/src/records/plugin.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "graphics")]
 use crate::records::ui::{
     spawn_employment_text, spawn_population_text, update_employment_text, update_population_text,
+    VacancyTextPlugin,
 };
 use crate::records::Records;
 use crate::records::{record_births, record_deaths, record_employment_rate};
@@ -13,7 +14,8 @@ pub struct RecordsPlugin;
 impl Plugin for RecordsPlugin {
     fn build(&self, app: &mut App) {
         #[cfg(feature = "graphics")]
-        app.add_systems(Startup, (spawn_population_text, spawn_employment_text))
+        app.add_plugins(VacancyTextPlugin)
+            .add_systems(Startup, (spawn_population_text, spawn_employment_text))
             .add_systems(Update, (update_population_text, update_employment_text));
 
         app.add_systems(

--- a/src/records/ui.rs
+++ b/src/records/ui.rs
@@ -116,7 +116,7 @@ pub fn update_vacancy_text(
     greg: Res<Gregslist>,
     mut q_text: Query<&mut Text, With<VacancyText>>,
 ) {
-    if let Some(mut text) = q_text.iter_mut().next() {
+    if let Ok(mut text) = q_text.get_single_mut() {
         text.0 = format!("Open roles: {}", greg.ads.len());
     }
 }


### PR DESCRIPTION
## Summary
- gate VacancyText and VacancyTextPlugin re-exports behind `graphics` feature
- gate main import of VacancyTextPlugin
- register `VacancyTextPlugin` in `RecordsPlugin`
- update vacancy text query to use single result

## Testing
- `apt-get install -y libasound2-dev libudev-dev pkg-config`
- `cargo build`
- `cargo build --features graphics`
- `cargo test --features graphics`


------
https://chatgpt.com/codex/tasks/task_e_68c746851120832a938db4c192f78240